### PR TITLE
Toast dynamic icon sizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-toast",
-  "version": "0.1.4",
+  "version": "0.1.5-alpha.0",
   "description": "Customizable Toast Notifications for SolidJS",
   "main": "./dist/solid-toast.cjs.js",
   "module": "./dist/solid-toast.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-toast",
-  "version": "0.1.5-alpha.0",
+  "version": "0.1.5",
   "description": "Customizable Toast Notifications for SolidJS",
   "main": "./dist/solid-toast.cjs.js",
   "module": "./dist/solid-toast.es.js",

--- a/src/util/styles.ts
+++ b/src/util/styles.ts
@@ -33,8 +33,12 @@ export const messageContainer: JSX.CSSProperties = {
 
 export const iconContainer: JSX.CSSProperties = {
   'flex-shrink': 0,
-  width: '20px',
-  height: '20px'
+  'min-width': '20px',
+  'min-height': '20px',
+  display: 'flex',
+  'align-items': 'center',
+  'justify-content': 'center',
+  'text-align': 'center',
 }
 
 export const iconCircle = keyframes`from{transform:scale(0)rotate(45deg);opacity:0;}to{transform:scale(1)rotate(45deg);opacity:1;}`;


### PR DESCRIPTION
Allows Custom Toast icons to be larger than 20px X 20px