### PR TITLE
Add `paused` attribute to allow for timespan animation

### DIFF
--- a/dev/src/App.tsx
+++ b/dev/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'solid-js';
+import { Component, createEffect, createMemo, createSignal, onCleanup } from 'solid-js';
 import toast, { Toaster } from '../../src';
 
 const makePromise = (): Promise<string> => {
@@ -26,11 +26,35 @@ const App: Component = () => {
       primary: '#ea580c',
       secondary: '#ffedd5'
     },
-    className: "border-2 border-orange-800 bg-orange-100",
+    className: "border-2 border-orange-800",
     style: {
-      color: '#c2410c'
+      color: '#c2410c',
+      background: '#ffedd5'
     },
     duration: Infinity
+  });
+  const popTimer = () => toast.custom((t) => {
+    const [life, setLife] = createSignal(100)
+    
+    createEffect(() => {
+      if (t.paused) return; 
+      const interval = setInterval(() => {
+        console.log(t.paused)
+        setLife(l => l - 0.5)
+      }, 10)
+
+      onCleanup(() => clearInterval(interval))
+    })
+
+    return (
+      <div class="bg-pink-100 shadow-md px-4 py-3 rounded overflow-hidden relative text-pink-700">
+        <div style={{width: `${life()}%`}} class="bg-pink-200 h-full absolute top-0 left-0" ></div>
+        <span class="relative" >Timer In The Background</span>
+      </div>
+    )
+  }, {
+    duration: 2000,
+    unmountDelay: 0
   });
 
   const closeAll = () => toast.dismiss();
@@ -52,7 +76,9 @@ const App: Component = () => {
         <button class={"loading"} onClick={popLoading}>Loading Toast</button>
         <button class={"promise"} onClick={popPromise}>Promise Toast</button>
         <button class={"custom"} onClick={popCustom}>Custom Styles</button>
+        <button class={"timer"}   onClick={popTimer}>Toast Timer</button>
         <button class={"close"}   onClick={closeAll}>Close all toasts</button>
+        
       </div>
     </div>
   );

--- a/dev/src/styles.css
+++ b/dev/src/styles.css
@@ -42,6 +42,10 @@ h1 {
   @apply button text-orange-800 bg-orange-200 hover:bg-orange-300
 }
 
+.timer {
+  @apply button text-pink-800 bg-pink-200 hover:bg-pink-300
+}
+
 .close {
   @apply button text-purple-800 bg-purple-200 hover:bg-purple-300
 }

--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src", "dev"]
+}

--- a/dev/tsconfig.node.json
+++ b/dev/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -123,7 +123,12 @@ export const dispatch = (action: Action) => {
         : dispatch({ type: ActionType.ADD_TOAST, toast: action.toast });
       break;
     case ActionType.START_PAUSE:
-      setStore('pausedAt', Date.now());
+      setStore(p((s) => {
+        s.pausedAt = Date.now();
+        s.toasts.forEach((t) => {
+          t.paused = true;
+        });
+      }));
       break;
     case ActionType.END_PAUSE:
       const pauseInterval = action.time - (store.pausedAt || 0);
@@ -132,6 +137,7 @@ export const dispatch = (action: Action) => {
           s.pausedAt = undefined;
           s.toasts.forEach((t) => {
             t.pauseDuration += pauseInterval;
+            t.paused = false;
           });
         })
       );

--- a/src/core/toast.ts
+++ b/src/core/toast.ts
@@ -18,6 +18,7 @@ export const createToast = (message: Message, type: ToastType = 'blank', options
   createdAt: Date.now(),
   visible: true,
   id: options.id || generateID(),
+  paused: false,
   style: {
     ...defaultToastOptions.style,
     ...defaultOpts().toastOptions?.style,

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -27,6 +27,7 @@ export interface Toast {
   icon?: Renderable;
   duration?: number;
   pauseDuration: number;
+  paused: boolean;
   position?: ToastPosition;
 
   ariaProps: {


### PR DESCRIPTION
Add a paused attribute to all `toast` instances. This will allow for adding a timer indicator typically seen on toasts. The usage of it is included in the dev examples folder under `Toast Timer`